### PR TITLE
Add fixes for CVE-2024-5535 and CVE-2024-24790

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,7 +1,7 @@
 ############################
 # STEP 1 build the image for creating the executable
 ############################
-FROM docker.io/library/golang:1.22-alpine3.19 as builder
+FROM docker.io/library/golang:1.22.5-alpine3.19 as builder
 
 # Install git + SSL ca certificates + make
 RUN apk update && apk upgrade && apk add --no-cache git ca-certificates make unzip g++ && update-ca-certificates && apk --no-cache add openssl wget && rm -rf /var/cache/apk/*
@@ -52,6 +52,9 @@ COPY --from=builder /app/synthetic-heart/agent /app/synthetic-heart/agent
 
 # Create a /tmp/ diretctory (required for go plugin for Unix Domain Socket)
 COPY --from=builder /app/synthetic-heart/.emptyfile /tmp/.emptyfile
+
+# Fix for CVE-2024-5535
+RUN apk add "openssl>3.1.6-r0"
 
 WORKDIR /app/synthetic-heart
 


### PR DESCRIPTION
## Description
[CVE-2024-5535](https://nvd.nist.gov/vuln/detail/CVE-2024-5535)
- alpine openssl cirical vulnerability fixes by requring openssl version > 3.1.6-r0
- [golang 1.22 backport commit](https://github.com/golang/go/commit/12d5810cdb1f73cf23d7a86462143e9463317fca) 

[CVE-2024-24790](https://nvd.nist.gov/vuln/detail/CVE-2024-24790)
- various 'Is' methods not working as expected, fixed by bumping builder image to golang:1.22.5 to include backported fix.
- [golang:1.22.5-alpine3.19 image layer details](https://hub.docker.com/layers/library/golang/1.22.5-alpine3.19/images/sha256-fba34f32048b9afd8400b225a0daecf72db210f107063e876a0e32b46e7b9259?context=repo&tab=vulnerabilities)


## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

_Vulnerability Fixing_

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
